### PR TITLE
Fix some error on centos 6

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -214,7 +214,7 @@ elsif data.site.rsync
 
   deploy_config = {
     method: :rsync,
-    user: rsync.user || ENV[:USER],
+    user: rsync.user || ENV["USER"],
     host: rsync.host,
     path: rsync.path,
     port: rsync.port || 22,


### PR DESCRIPTION
For some reason, it seems that the ruby of RHEL 6 do not recognize :USER as a symbol. Using a string make it work fine.
