### PR TITLE
Cache fixes

### DIFF
--- a/data/site.yml
+++ b/data/site.yml
@@ -2,6 +2,9 @@ name: Planet Gluster
 subhead: Blogging about Gluster
 domain: planet.gluster.org
 
+# Number of hours to ensure invalidated cache, and feeds are re-fetched
+planet_refresh: 6
+
 # Be sure to set up and install Juvia before enabling!
 #has_comments: true
 

--- a/lib/planet.rb
+++ b/lib/planet.rb
@@ -35,6 +35,10 @@ end
 def planet_feeds
   return $PLANET_FEEDS if $PLANET_FEEDS
 
+  # Time to force a planet feed re-fetch; 6 hours by default
+  # Configurable in data/site.yml; see "planet_refresh"
+  time_ago = (data.site['planet_refresh'] || 6) * 3600
+
   all_feed_entries = []
 
   if data[:feeds] # ensure data/feeds.yml exists
@@ -45,6 +49,8 @@ def planet_feeds
       next unless feed_url
 
       begin
+        OpenURI::Cache.invalidate(feed_url, Time.now - time_ago.to_i)
+
         feed = Feedjira::Feed.parse(open(feed_url).read)
         entries = feed.entries
 


### PR DESCRIPTION
This ensures that cache is invalidated at a site-specified time, so that the feed refetch WILL happen after a customizable number of hours, regardless of cache settings.

By default, that's defined as 6 hours. It can be changed in `data/site.yml`, and fractional hours are supported too.
