### PR TITLE
Cope better with server sending empty document

### DIFF
--- a/lib/planet.rb
+++ b/lib/planet.rb
@@ -68,7 +68,7 @@ def parse_feed(feed_raw, feed_url = 'unknown feed')
   Feedjira::Feed.parse(feed_raw) unless feed_raw.to_s == ''
 rescue
   head = http_head(feed_url)
-  err_msg = "Server sent '#{head.content_type}'"
+  err_msg = if defined?(head.content_type) then "Server sent '#{head.content_type}'" else "No data sent" end
   puts "ERR:  #{err_msg}; problem parsing '#{feed_url}'"
   nil
 end


### PR DESCRIPTION
Sometime, a server just fail to send anything but do not
fail correctly in the HTTP way. In turn, this break the assumption
made in this code, and make the build fail with this:

```
undefined method `content_type' for nil:NilClass
/srv/middleman_builder/planet/lib/planet.rb:71:in `rescue in parse_feed'
/srv/middleman_builder/planet/lib/planet.rb:68:in `parse_feed'
```

And unlike the others errors, this one is fatal to the build.
