### PR TITLE
Fix Mjanja Tech  blog

### DIFF
--- a/data/feeds.yml
+++ b/data/feeds.yml
@@ -151,7 +151,7 @@ Linux Journal GlusterFS Feed:
 Mjanja Tech » GlusterFS:
   image: ant.png
   rounded: false
-  feed: https://mjanja.co.ke/tag/glusterfs/feed/
+  feed: https://mjanja.ch/tag/glusterfs/feed/
 
 My Humble Abode:
   image: ant.png


### PR DESCRIPTION
The certificate used for https is valid only for mjanja.ch,
so fixing the feed url should fix the error 400
